### PR TITLE
Create simple test for subFlow performance

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -46,6 +46,12 @@
         "env": {
             "jest": true
         }
-    }
+    },
+    {
+      "files": ["benchmark/**/*"],
+      "rules": {
+          "no-console": "off"
+      }
+  }
   ]
 }

--- a/benchmark/subFlow.benchmark.ts
+++ b/benchmark/subFlow.benchmark.ts
@@ -1,0 +1,52 @@
+import { Caminho } from '../src/caminho'
+import { sleep } from '../src/helpers/sleep'
+import { getNumberedArray } from '../test/mocks/array.mock'
+import { getMockedGenerator } from '../test/mocks/generator.mock'
+
+async function runSubflowBenchmark(parentItems: number, childItemsPerParent: number) {
+  console.log(`Initialized with ${parentItems} parent items, and ${parentItems * childItemsPerParent} child items.`)
+  await sleep(100)
+  console.time('initialize steps')
+  const steps = initializeSteps(parentItems, childItemsPerParent)
+
+  const batchStep = {
+    fn: steps.getBatchSleeper(50),
+    provides: 'batch1',
+    options: { batch: { maxSize: 50, timeoutMs: 5 } },
+  }
+
+  const subSource = { fn: steps.childGenerator, maxItemsFlowing: 1_000, provides: 'subSource1' }
+  console.timeEnd('initialize steps')
+  console.time('initialize caminho')
+
+  const benchmarkCaminho = new Caminho()
+    .source({ fn: steps.parentGenerator, maxItemsFlowing: 1_000, provides: 'source1' })
+    .pipe({ fn: steps.sleeper, provides: 'pipe1' })
+    .subFlow(subSource, (caminho) => caminho
+      .pipe(batchStep), steps.accumulator)
+    .pipe({ fn: steps.sleeper, provides: 'pipe2' })
+
+  console.timeEnd('initialize caminho')
+  console.time('run caminho')
+  await benchmarkCaminho.run()
+  console.timeEnd('run caminho')
+}
+
+function initializeSteps(parentItems: number, childItemsPerParent: number) {
+  const accumulator = { fn: (acc: number) => acc + 1, seed: 0, provides: 'accumulator1' }
+
+  return {
+    parentGenerator: getMockedGenerator(getNumberedArray(parentItems)),
+    childGenerator: getMockedGenerator(getNumberedArray(childItemsPerParent)),
+    sleeper: async () => 'something',
+    accumulator,
+    getBatchSleeper(size: number) {
+      const array = getNumberedArray(size)
+      return function batchSleeper() {
+        return array
+      }
+    },
+  }
+}
+
+runSubflowBenchmark(5_0000, 1000)

--- a/package.json
+++ b/package.json
@@ -9,8 +9,9 @@
     "build": "npm run clean && tsc --build",
     "clean": "tsc --build --clean",
     "lint": "eslint ./src ./test",
-    "lint-fix": "eslint ./src ./test --fix",
-    "watch-test": "jest -o --watch"
+    "lint-fix": "eslint ./src ./test ./benchmark --fix",
+    "watch-test": "jest -o --watch",
+    "benchmark-subflow": "npx ts-node benchmark/subFlow.benchmark.ts"
   },
   "repository": {
     "type": "git",

--- a/test/mocks/array.mock.ts
+++ b/test/mocks/array.mock.ts
@@ -1,0 +1,3 @@
+export function getNumberedArray(size: number) {
+  return new Array(size).fill(0).map((_, index) => index + 1)
+}

--- a/test/subFlow.test.ts
+++ b/test/subFlow.test.ts
@@ -1,5 +1,6 @@
 import { Accumulator, Caminho } from '../src/caminho'
 import { ValueBag } from '../src/types'
+import { getNumberedArray } from './mocks/array.mock'
 import { getMockedGenerator } from './mocks/generator.mock'
 
 describe('Sub-Flow', () => {
@@ -102,7 +103,7 @@ function getCompanySteps() {
     .mockImplementation((valueBag: ValueBag) => valueBag.companyId % 2 !== 0)
 
   const saveCompanyFn = jest.fn().mockName('saveCompany').mockResolvedValue([])
-  const companyIdGeneratorFn = getMockedGenerator(new Array(3).fill(0).map((_, index) => index + 1))
+  const companyIdGeneratorFn = getMockedGenerator(getNumberedArray(3))
 
   const generator = { fn: companyIdGeneratorFn, provides: 'companyId' }
   const fetchStatus = { fn: fetchCompanyStatusFn, provides: 'companyStatus' }


### PR DESCRIPTION
Initialized with 50000 parent items, and 50.000.000 child items.
initialize steps: 1.749ms
initialize caminho: 0.619ms
run caminho: 1:54.395 (m:ss.mmm)

Running on Macbook M1 8gb.