### PR TITLE
Change Caminho to use "Operators" state instead of "Observable" state

### DIFF
--- a/benchmark/subFlow.benchmark.ts
+++ b/benchmark/subFlow.benchmark.ts
@@ -15,14 +15,14 @@ async function runSubflowBenchmark(parentItems: number, childItemsPerParent: num
     options: { batch: { maxSize: 50, timeoutMs: 5 } },
   }
 
-  const subSource = { fn: steps.childGenerator, maxItemsFlowing: 1_000, provides: 'subSource1' }
   console.timeEnd('initialize steps')
   console.time('initialize caminho')
 
   const benchmarkCaminho = new Caminho()
     .source({ fn: steps.parentGenerator, maxItemsFlowing: 1_000, provides: 'source1' })
     .pipe({ fn: steps.sleeper, provides: 'pipe1' })
-    .subFlow(subSource, (caminho) => caminho
+    .subFlow((caminho) => caminho
+      .source({ fn: steps.childGenerator, maxItemsFlowing: 1_000, provides: 'subSource1' })
       .pipe(batchStep), steps.accumulator)
     .pipe({ fn: steps.sleeper, provides: 'pipe2' })
 

--- a/src/operations/generator.ts
+++ b/src/operations/generator.ts
@@ -10,6 +10,7 @@ export interface SourceParams {
   fn: () => AsyncGenerator
   provides: string
   maxItemsFlowing?: number
+  name?: string
 }
 
 export interface SourceResult {

--- a/src/operations/stepLogger.ts
+++ b/src/operations/stepLogger.ts
@@ -2,7 +2,7 @@ import { OnEachStep, OperationStatus, OperationType } from '../types'
 
 export type Logger = () => void
 
-export function getLogger(operationType: OperationType, executor: { name: string }, onEachStep?: OnEachStep) {
+export function getLogger(operationType: OperationType, name: string, onEachStep?: OnEachStep) {
   if (onEachStep) {
     let stepStartedAt: number = Date.now()
 
@@ -12,7 +12,7 @@ export function getLogger(operationType: OperationType, executor: { name: string
       stepStartedAt = now
 
       onEachStep({
-        name: executor.name,
+        name,
         type: operationType,
         status: OperationStatus.SUCCESS,
         tookMs,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,9 +1,15 @@
+import { Observable, OperatorFunction } from 'rxjs'
 import { BatchParams } from './operations/batch'
 import { PipeParams } from './operations/pipe'
 
 // TODO: Proper typing for ValueBag!
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type ValueBag = Record<string, any>
+
+type ValueBagOrBatch = ValueBag | ValueBag[]
+
+export type OperatorApplier = (observable: Observable<ValueBag>) => Observable<ValueBag>
+export type Operator = OperatorFunction<ValueBagOrBatch, ValueBagOrBatch>
 
 export type PipeGenericParams = PipeParams | BatchParams
 


### PR DESCRIPTION
Initialized with 50.000 parent items, and 50.000.000 child items.
initialize steps: 1.839ms
initialize caminho: 0.61ms
run caminho: 50.751s

Running on Macbook M1 8gb.