### PR TITLE
Fix cases which pending items flowing will not be accounted after an error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "caminho",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "caminho",
-      "version": "1.7.1",
+      "version": "1.7.2",
       "license": "ISC",
       "dependencies": {
         "rxjs": "^7.8.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
       },
       "devDependencies": {
         "@types/jest": "^29.5.12",
+        "@types/node": "^20.16.0",
         "@typescript-eslint/eslint-plugin": "^6.21.0",
         "@typescript-eslint/parser": "^6.21.0",
         "eslint": "^8.57.0",
@@ -1417,10 +1418,13 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "14.18.63",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
-      "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
-      "dev": true
+      "version": "20.16.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.16.0.tgz",
+      "integrity": "sha512-vDxceJcoZhIVh67S568bm1UGZO0DX0hpplJZxzeXMKwIPLn190ec5RRxQ69BKhX44SUGIxxgMdDY557lGLKprQ==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~6.19.2"
+      }
     },
     "node_modules/@types/semver": {
       "version": "7.5.8",
@@ -5283,6 +5287,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/undici-types": {
+      "version": "6.19.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.6.tgz",
+      "integrity": "sha512-e/vggGopEfTKSvj4ihnOLTsqhrKRN3LeO6qSN/GxohhuRv8qH9bNQ4B8W7e/vFL+0XTnmHPB4/kegunZGA4Org==",
+      "dev": true
+    },
     "node_modules/update-browserslist-db": {
       "version": "1.0.13",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz",
@@ -6569,10 +6579,13 @@
       "dev": true
     },
     "@types/node": {
-      "version": "14.18.63",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
-      "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
-      "dev": true
+      "version": "20.16.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.16.0.tgz",
+      "integrity": "sha512-vDxceJcoZhIVh67S568bm1UGZO0DX0hpplJZxzeXMKwIPLn190ec5RRxQ69BKhX44SUGIxxgMdDY557lGLKprQ==",
+      "dev": true,
+      "requires": {
+        "undici-types": "~6.19.2"
+      }
     },
     "@types/semver": {
       "version": "7.5.8",
@@ -9347,6 +9360,12 @@
         "has-symbols": "^1.0.2",
         "which-boxed-primitive": "^1.0.2"
       }
+    },
+    "undici-types": {
+      "version": "6.19.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.6.tgz",
+      "integrity": "sha512-e/vggGopEfTKSvj4ihnOLTsqhrKRN3LeO6qSN/GxohhuRv8qH9bNQ4B8W7e/vFL+0XTnmHPB4/kegunZGA4Org==",
+      "dev": true
     },
     "update-browserslist-db": {
       "version": "1.0.13",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "caminho",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "description": "Tool for creating efficient data pipelines in a JavaScript environment",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm5/index.js",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
   "license": "ISC",
   "devDependencies": {
     "@types/jest": "^29.5.12",
+    "@types/node": "^20.16.0",
     "@typescript-eslint/eslint-plugin": "^6.21.0",
     "@typescript-eslint/parser": "^6.21.0",
     "eslint": "^8.57.0",

--- a/src/operators/generator.ts
+++ b/src/operators/generator.ts
@@ -38,9 +38,9 @@ export function wrapGeneratorWithBackPressure(
   loggers: Loggers,
 ) {
   const wrappedGenerator = wrapGenerator(generatorParams, loggers)
-  return async function* wrappedGeneratorWithBackPressure(initialBag: ValueBag) {
-    for await (const value of wrappedGenerator(initialBag)) {
-      pendingDataControl.increment()
+  return async function* wrappedGeneratorWithBackPressure(initialBag: ValueBag, runId: string) {
+    for await (const value of wrappedGenerator({ ...initialBag })) {
+      pendingDataControl.increment(runId)
       yield value
       if (needsToWaitForBackpressure(pendingDataControl, maxItemsFlowing)) {
         await waitOnBackpressure(maxItemsFlowing, pendingDataControl)

--- a/src/operators/helpers/operatorHelpers.ts
+++ b/src/operators/helpers/operatorHelpers.ts
@@ -5,6 +5,7 @@ import { type BatchParams } from '../batch'
 import { type PipeParams } from '../pipe'
 
 export type OperatorApplier = (observable: Observable<ValueBag>) => Observable<ValueBag>
+export type OperatorApplierWithRunId = (runId: string) => OperatorApplier
 
 export function isBatch(params: PipeParams | BatchParams): params is BatchParams {
   return !!(params as BatchParams)?.batch
@@ -12,7 +13,8 @@ export function isBatch(params: PipeParams | BatchParams): params is BatchParams
 
 export function applyOperator(
   observable: Observable<ValueBag>,
-  operatorApplier: OperatorApplier,
+  operatorApplier: OperatorApplierWithRunId,
+  runId: string,
 ): Observable<ValueBag> {
-  return operatorApplier(observable)
+  return operatorApplier(runId)(observable)
 }

--- a/src/utils/PendingDataControl.ts
+++ b/src/utils/PendingDataControl.ts
@@ -1,17 +1,29 @@
 export class PendingDataControlInMemory implements PendingDataControl {
   public size = 0
+  private buckets = new Map()
 
-  increment(value = 1): void {
+  increment(bucketId: string, value = 1): void {
     this.size += value
+    const current = this.buckets.get(bucketId) ?? 0
+    this.buckets.set(bucketId, current + value)
   }
 
-  decrement(value = 1): void {
+  decrement(bucketId: string, value = 1): void {
     this.size -= value
+    const current = this.buckets.get(bucketId)
+    this.buckets.set(bucketId, current - value)
+  }
+
+  destroyBucket(bucketId: string) {
+    const inBucket = this.buckets.get(bucketId) ?? 0
+    this.size -= inBucket
+    this.buckets.delete(bucketId)
   }
 }
 
 export type PendingDataControl = {
   size: number
-  increment: (value?: number) => void
-  decrement: (value?: number) => void
+  increment: (bucketId: string, value?: number) => void
+  decrement: (bucketId: string, value?: number) => void
+  destroyBucket: (bucketId: string) => void
 }

--- a/src/utils/generateId.ts
+++ b/src/utils/generateId.ts
@@ -1,0 +1,3 @@
+export function generateId() {
+  return `${Date.now().toString(36)}-${Math.random().toString(36).substr(2, 9)}`
+}

--- a/test/unit/PendingDataControl.test.ts
+++ b/test/unit/PendingDataControl.test.ts
@@ -4,31 +4,31 @@ describe('PendingDataControl', () => {
   test('PendingDataControl should properly increment 1 value as default and start with zero', async () => {
     const pendingDataControl = new PendingDataControlInMemory()
     expect(pendingDataControl.size).toEqual(0)
-    pendingDataControl.increment()
+    pendingDataControl.increment('a')
     expect(pendingDataControl.size).toEqual(1)
   })
 
   test('PendingDataControl should properly increment provided value', async () => {
     const pendingDataControl = new PendingDataControlInMemory()
-    pendingDataControl.increment()
+    pendingDataControl.increment('a')
     expect(pendingDataControl.size).toEqual(1)
-    pendingDataControl.increment(5)
+    pendingDataControl.increment('b', 5)
     expect(pendingDataControl.size).toEqual(6)
   })
 
   test('PendingDataControl should properly decrement 1 value as default and start with zero', async () => {
     const pendingDataControl = new PendingDataControlInMemory()
-    pendingDataControl.increment()
+    pendingDataControl.increment('a')
     expect(pendingDataControl.size).toEqual(1)
-    pendingDataControl.decrement()
+    pendingDataControl.decrement('b')
     expect(pendingDataControl.size).toEqual(0)
   })
 
   test('PendingDataControl should properly decrement provided value', async () => {
     const pendingDataControl = new PendingDataControlInMemory()
-    pendingDataControl.increment(5)
+    pendingDataControl.increment('a', 5)
     expect(pendingDataControl.size).toEqual(5)
-    pendingDataControl.decrement(4)
+    pendingDataControl.decrement('b', 4)
     expect(pendingDataControl.size).toEqual(1)
   })
 })


### PR DESCRIPTION

### Bug

The system had a bug which caused inconsistencies in the back-pressure system that eventually lead to stuck process.
This happened when there were many executions (`.run()`) for the same reused Caminho instance, so when some of the operators threw an error in the execution, the back-pressure system would not decrement the pending items for the items that has generated but haven't finished all the operators, therefore, when back-pressure system compared the `maxItemsFlowing` with the current number of items flowing, it was still accounting for items that were not in memory anymore.
Over time, the Caminho instance was allowing less and less items to be in memory, according to the number of items that were flowing during a failed execution, so at some point, the number of "ghost" items would reach `maxItemsFlowing` and stop processing completely.

### Fix

The back-pressure system currently accounts all runs for a given Caminho instance, this gives a very good control of how many items can be in memory at the same time, making your process memory allocation very predictable, and even executions more efficient, the goal of this fix was to NOT change this behaviour, therefore, fixing this bug took more effort than simply changing the back-pressure to be per execution.  
The fix consisted of generating a `runId` for each execution, so this ID allows to control the back-pressure isolated, and reset all the "pending items" for a given run whenever the flow for the given execution is ended, no matter if it had an error or not.
In the fix, the `runId` was intentionally not part of the `ValueBag`, this was done to avoid internal values of Caminho being available to the step functions, therefore, the `OperatorApplierWithRunId` was created.

## Benchmark

#### Before

Subflow:
Parent Items: 50000
Child Items: 50000000
initialize steps: 1.437ms
initialize caminho: 0.372ms
run caminho: 1:26.565 (m:ss.mmm)

Parallel:
Parent Items: 5000
Child Items: 5000000
initialize steps: 0.304ms
initialize caminho: 0.038ms
run caminho: 27.630s

#### After

Subflow:
Parent Items: 50000
Child Items: 50000000
initialize steps: 1.445ms
initialize caminho: 0.441ms
run caminho: 1:30.135 (m:ss.mmm)

Parallel: 
Parent Items: 5000
Child Items: 5000000
initialize steps: 0.262ms
initialize caminho: 0.036ms
run caminho: 28.243s